### PR TITLE
Add missing function [ liff.getIDToken() ]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -216,6 +216,11 @@ declare global {
          *
          */
         function initPlugins(plugins: LIFFPlugins[]): Promise<void>;
+
+        /**
+         * Gets the ID token.
+         */
+        function getIDToken(): string;
         
         /**
          * Gets the payload of the ID token that's automatically acquired by `liff.init()` The payload includes the user display name, profile image URL, and email address.


### PR DESCRIPTION
I want to get the ID Token but this package is missing the function to get the ID Token but I found it in [sdk.js](https://static.line-scdn.net/liff/edge/2.1/sdk.js)

![image](https://user-images.githubusercontent.com/46470102/79236746-90a33d00-7e97-11ea-8e63-8fcbd7dd535e.png)
