### PR TITLE
Exclude ImageMap from LIFF Message type and type guard for messages at shareTargetPicker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ In `.tsconfig`, add `liff-type` to `types` in `compilerOptions`
 In your code, you can access `liff` directly as global variable without window! 
 
 ![example](doc/example.png)
+
+### Versioning
+
+Major and Minor Version are matched with LIFF SDK.
+
+Patch is bug fixed or improvement.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="@line/bot-sdk" />
-import LINE = require('@line/bot-sdk')
+import LINE = require('@line/bot-sdk');
 
 declare type LIFFConfig = {
     liffId: string,
@@ -111,7 +111,9 @@ declare type LiffContextData = {
     utouId?: string,
     roomId?: string,
     groupId?: string,
- }
+}
+
+declare type LIFFMessage = Exclude<LINE.Message, LINE.ImageMapMessage>
 
 declare global {
     namespace liff {
@@ -196,7 +198,7 @@ declare global {
         /**
          * Sends messages on behalf of the user to the chat screen where the LIFF app is opened.
          */
-        function sendMessages(messages: LINE.Message[]): Promise<void>;
+        function sendMessages(messages: LIFFMessage[]): Promise<void>;
         
         /**
          * Starts LINE's QR code reader and gets the string read by the user. To start the QR code reader, grant ScanQR permission to the LIFF app in the LINE Developers Console.
@@ -236,7 +238,7 @@ declare global {
          * Displays the target picker (screen for selecting a group or friend) and sends the message created by the developer to the selected target. This message appears to your group or friends as if you had sent it.
          * @param messages - maximum 5 messages
          */
-        function shareTargetPicker(messages: LINE.Message[]): Promise<void>;
+        function shareTargetPicker(messages: [LIFFMessage?, LIFFMessage?, LIFFMessage?, LIFFMessage?, LIFFMessage?]): Promise<void>;
 
         /**
          * Gets the Promise object that resolves when you run liff.init() for the first time after starting the LIFF app. If you use liff.ready, you can execute any process after the completion of liff.init().

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/S-O-L-A-R/liff-type#readme",
   "dependencies": {
-    "@line/bot-sdk": "^6.8.2"
+    "@line/bot-sdk": "^6.8.4"
   },
   "devDependencies": {
     "standard-version": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@line/bot-sdk@^6.8.2":
+"@line/bot-sdk@^6.8.4":
   version "6.8.4"
-  resolved "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-6.8.4.tgz#9262ff5989d48edba35c851f7401a6e26d83c32d"
+  resolved "https://registry.yarnpkg.com/@line/bot-sdk/-/bot-sdk-6.8.4.tgz#9262ff5989d48edba35c851f7401a6e26d83c32d"
   integrity sha512-ul0GT9CHW2A5K3xUi6BRuFSWZfePXcnArFFeDtf4wbLhVMZoO3yyslrEaDuNt4UiKYK1BxU09LvXNU7/ha4i9w==
   dependencies:
     "@types/body-parser" "^1.17.1"


### PR DESCRIPTION
* As #8 said that ImageMapMessage is unavailable in LIFF, so I exclude it from Message type.

* shareTargetPicker maximum number of messages is 5, so I add type guard for it.

* Versioning guideline